### PR TITLE
feat(gen): enums from structs

### DIFF
--- a/cmd/cuetsy/test.cue
+++ b/cmd/cuetsy/test.cue
@@ -2,6 +2,10 @@ package cuetsy
 
 E1: "e1str1" | "e1str2" | "e1str3" @cuetsy(targetType="enum")
 E2: "e2str1" | "e2str2" | "e2str3" | "e2str4" @cuetsy(targetType="enum")
+E3: {
+  Walla: "laadeedaa"
+  run: "OMG"
+} @cuetsy(targetType="enum")
 
 I1: {
   I1_OptionalDisjunctionLiteral?: "other" | "values" | 2


### PR DESCRIPTION
Enables converting string-only structs to enums as a more fine-grained
alternative to already supported disjunctions

Fixes #1 